### PR TITLE
Artem/alt 18 верстка страницы лидерборда

### DIFF
--- a/packages/client/.stylelintrc.json
+++ b/packages/client/.stylelintrc.json
@@ -9,6 +9,7 @@
     "color-function-notation": null,
     "shorthand-property-no-redundant-values": null,
     "no-empty-source": null,
-    "selector-class-pattern": null
+    "selector-class-pattern": null,
+    "media-feature-range-notation": "prefix"
   }
 }

--- a/packages/client/src/components/Button/Button.pcss
+++ b/packages/client/src/components/Button/Button.pcss
@@ -9,6 +9,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  justify-content: center;
 }
 
 .button:hover {

--- a/packages/client/src/components/Leaderboard/LeaderboardItem/LeaderboardItem.pcss
+++ b/packages/client/src/components/Leaderboard/LeaderboardItem/LeaderboardItem.pcss
@@ -1,0 +1,47 @@
+.leaderboard-item {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--color-border);
+  align-items: center;
+
+  &__position {
+    font-size: 1.25rem;
+    font-weight: 400;
+  }
+
+  &__avatar {
+    width: 72px;
+    height: 72px;
+    object-fit: cover;
+    flex-shrink: 0;
+
+    > img {
+      width: 100%;
+      height: 100%;
+      border-radius: 9999px;
+    }
+  }
+
+  &__name {
+    font-size: 1.25rem;
+    flex-grow: 1;
+  }
+
+  &__level {
+    font-size: 1.25rem;
+    font-weight: 400;
+    width: 120px;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .leaderboard-item {
+    flex-direction: column;
+
+    &__level {
+      width: auto;
+    }
+  }
+}

--- a/packages/client/src/components/Leaderboard/LeaderboardItem/index.tsx
+++ b/packages/client/src/components/Leaderboard/LeaderboardItem/index.tsx
@@ -1,0 +1,23 @@
+import './LeaderboardItem.pcss'
+
+interface Props {
+  display_name: string
+  level: number
+  position: number
+  avatar: string
+}
+
+const LeaderboardItem = ({ display_name, level, position, avatar }: Props) => {
+  return (
+    <div className="leaderboard-item">
+      <div className="leaderboard-item__position">{position}</div>
+      <div className="leaderboard-item__avatar">
+        <img src={avatar} alt={display_name} />
+      </div>
+      <div className="leaderboard-item__name">{display_name}</div>
+      <div className="leaderboard-item__level">{level}</div>
+    </div>
+  )
+}
+
+export default LeaderboardItem

--- a/packages/client/src/components/Leaderboard/LeaderboardList/LeaderboardList.pcss
+++ b/packages/client/src/components/Leaderboard/LeaderboardList/LeaderboardList.pcss
@@ -1,0 +1,33 @@
+.leaderboard-list {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+
+  &__header {
+    display: flex;
+    gap: 1rem;
+    margin: 2.25rem 0;
+  }
+}
+
+.list-header {
+  &__player {
+    flex-grow: 1;
+    flex-shrink: 1;
+    padding-left: 32px;
+    color: var(--color-text-gray);
+  }
+
+  &__level {
+    width: 120px;
+    color: var(--color-text-gray);
+  }
+}
+
+@media (max-width: 575.98px) {
+  .leaderboard-list {
+    &__header {
+      display: none;
+    }
+  }
+}

--- a/packages/client/src/components/Leaderboard/LeaderboardList/index.tsx
+++ b/packages/client/src/components/Leaderboard/LeaderboardList/index.tsx
@@ -1,0 +1,67 @@
+import LeaderboardItem from '../LeaderboardItem'
+import defaultAvatar from '../../../assets/images/default-avatar.jpg'
+import './LeaderboardList.pcss'
+import { useState } from 'react'
+
+const mockUsers = [
+  {
+    id: 1,
+    display_name: 'Bret',
+    level: 1023,
+    avatar: defaultAvatar,
+  },
+  {
+    id: 2,
+    display_name: 'Antonette',
+    level: 238,
+    avatar: defaultAvatar,
+  },
+  {
+    id: 3,
+    display_name: 'Samantha',
+    level: 18,
+    avatar: defaultAvatar,
+  },
+  {
+    id: 4,
+    display_name: 'Karianne',
+    level: 10,
+    avatar: defaultAvatar,
+  },
+  {
+    id: 5,
+    display_name: 'Kamren',
+    level: 1,
+    avatar: defaultAvatar,
+  },
+  {
+    id: 6,
+    display_name: 'Leopoldo_Corkery',
+    level: 0,
+    avatar: defaultAvatar,
+  },
+]
+
+const LeaderboardList = () => {
+  const [users] = useState(mockUsers)
+
+  return (
+    <div className="leaderboard-list">
+      <div className="leaderboard-list__header list-header">
+        <div className="list-header__player ">Игрок</div>
+        <div className="list-header__level">Уровень</div>
+      </div>
+      {users.map((user, index) => (
+        <LeaderboardItem
+          avatar={user.avatar}
+          position={index + 1}
+          display_name={user.display_name}
+          level={user.level}
+          key={user.id}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default LeaderboardList

--- a/packages/client/src/components/Modal/Modal.pcss
+++ b/packages/client/src/components/Modal/Modal.pcss
@@ -1,4 +1,9 @@
 .app-modal {
+  h3 {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+  }
+
   position: fixed;
   inset: 0;
   width: 100%;

--- a/packages/client/src/pages/LeaderbordPage.tsx
+++ b/packages/client/src/pages/LeaderbordPage.tsx
@@ -1,8 +1,30 @@
-const LeaderbordPage: React.FC = () => {
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import Button from '../components/Button'
+import { FaArrowLeft } from 'react-icons/fa'
+import LeaderboardList from '../components/Leaderboard/LeaderboardList'
+
+const LeaderbordPage = () => {
+  const navigate = useNavigate()
+
+  const pageTitle = 'Leaderboard | Water Puzzle'
+  const iconBackStyle = { fill: 'var(--color-text-gray)', fontSize: '1.25rem' }
+
+  useEffect(() => {
+    document.title = pageTitle
+  }, [])
+
   return (
-    <>
-      <h1>Leaderbord page</h1>
-    </>
+    <div className="page-wrap page-wrap_blue">
+      <main className="container card card_full">
+        <Button onClick={() => navigate(-1)} styleType="tertiary">
+          <FaArrowLeft style={iconBackStyle} />
+          Назад
+        </Button>
+        <h1 className="page-title">Таблица лидеров</h1>
+        <LeaderboardList />
+      </main>
+    </div>
   )
 }
 

--- a/packages/client/src/styles/App.pcss
+++ b/packages/client/src/styles/App.pcss
@@ -3,6 +3,11 @@
   width: 100%;
   padding: 3rem;
 
+  .page-title {
+    text-align: center;
+    margin: 2.25rem 0;
+  }
+
   &_blue {
     background-color: var(--color-bg-blue);
   }

--- a/packages/client/src/styles/App.pcss
+++ b/packages/client/src/styles/App.pcss
@@ -42,7 +42,7 @@
   }
   .card {
     background-color: var(--color-white);
-    border-radius: 32px;
+    border-radius: var(--border-radius-card);
     &_full {
       padding: 3rem;
     }

--- a/packages/client/src/styles/vars.pcss
+++ b/packages/client/src/styles/vars.pcss
@@ -25,4 +25,5 @@
   --padding-form: 25px 40px;
   --color-bg-blue: #86d3ff;
   --color-text-green: #22c55e;
+  --border-radius-card: 32px;
 }


### PR DESCRIPTION
### Верстка страницы "Таблица лидеров"
Страница доступна по роуту /leaderboard
В верстке используются пока моковые данные юзеров

Дополнительно:
- Поправил стили у кнопки, прошлым пиаром немного сломал центрирование текста внутри кнопки, сейчас испра
вил.
- В css-переменные добавил стиль для скругления карточек - --border-radius-card: 32px;

<img width="910" alt="Снимок экрана 2023-05-03 в 22 53 06" src="https://user-images.githubusercontent.com/18618740/236003955-90cca606-e098-4cc6-90c5-e0a8e4e5abfe.png">