### PR TITLE
commit

### DIFF
--- a/packages/client/src/pages/LevelPage.tsx
+++ b/packages/client/src/pages/LevelPage.tsx
@@ -145,6 +145,31 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
     setCountColor(Number(event.target.value))
   }
 
+  function activateFullscreen(element : Element) {
+    if(element.requestFullscreen) {
+      element.requestFullscreen();        // W3C spec
+    }
+  };
+  
+  function deactivateFullscreen() {
+    if(document.exitFullscreen) {
+      document.exitFullscreen();
+    }
+  };
+
+  function fullScreenToggle() {
+    let caption = document!.getElementById("toggler")!.innerHTML; 
+    if (caption == "Полный экран") {
+      activateFullscreen(document.documentElement);
+      caption = "В окне"
+    }
+    else {
+      deactivateFullscreen();
+      caption = "Полный экран"
+    }
+    document!.getElementById("toggler")!.innerHTML = caption;
+  }
+
   return (
     <div>
       <div style={{ margin: '20px' }}>
@@ -158,6 +183,9 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
         </select>
         <button onClick={reCreateAllBottles} style={{ marginLeft: '20px' }}>
           Применить
+        </button>
+        <button id="toggler" onClick={fullScreenToggle} style={{ marginLeft: '20px' }}>
+          Полный экран
         </button>
       </div>
       {arraySettingsBottle.map((bottle, idx) => (


### PR DESCRIPTION
### Какую задачу решаем

Добавление FullScreen API в приложение на страницу Level Page

### Скриншоты/видяшка 

![image](https://github.com/theotheo46/react/assets/62952187/28f6bae8-8272-44bf-91d0-e83cb880032e)

на страницу level Page добавил кнопку c заголовками **В окне / Полный экран**, по клику на которую происходит переход в полноэкранный режим и выход из него

### TBD 

После реализации в этой странице Redux можно там добавить флаг описывающий текущее состояние полноэкранного режима  и логику привязать к состоянию этого флага а не к заголовку кнопки. Кроме того - сейчас некорректно обрабатывается выход из полноэкранного режима по кнопке Esc - для корректной обработки надо реализовать
```
document.addEventListener("fullscreenchange", () => {
  if (document.fullscreenElement===null) {
    console.log("Exited fullscreen");
  } else {
    console.log("Entered fullscreen");
  }
});
```

вопрос где - возможно вешать это обработчик в useEffect ? 

Кроме того - после реализации игровой логики надо перейти на React Component Button вместо HTML элемента
Я отложил эти изменения на потом так как сейчас на данной странице представлен черновой вариант до окончания разработки механики игры.