### PR TITLE
Artem/alt 27 реализация начала и завершения игры

### DIFF
--- a/packages/client/src/components/Game/FinishGame/FinishGame.pcss
+++ b/packages/client/src/components/Game/FinishGame/FinishGame.pcss
@@ -20,6 +20,12 @@
       object-fit: cover;
     }
   }
+
+  &__btn{
+    display: flex;
+    gap: 1rem;
+  }
+
 }
 
 .finish-game-review {

--- a/packages/client/src/components/Game/FinishGame/FinishGame.pcss
+++ b/packages/client/src/components/Game/FinishGame/FinishGame.pcss
@@ -21,11 +21,10 @@
     }
   }
 
-  &__btn{
+  &__btn {
     display: flex;
     gap: 1rem;
   }
-
 }
 
 .finish-game-review {

--- a/packages/client/src/components/Game/FinishGame/index.tsx
+++ b/packages/client/src/components/Game/FinishGame/index.tsx
@@ -64,35 +64,32 @@ const FinishGame = () => {
   */
 
   function updateLevel() {
-    if (
-      countColors === 10 &&
-      countLayersInBottle === 10 &&
-      countEmptyBottles === 1
-    ) {
-      dispatch(resetLevel())
-    } else if (
-      (lastUpdateParam === '' || lastUpdateParam === 'epmtyBottles') &&
-      countColors < 10
-    ) {
-      dispatch(setCountColors(countColors + 1))
-      dispatch(setLastUpdateParam('countColors'))
-    } else if (
-      (lastUpdateParam === '' || lastUpdateParam === 'countColors') &&
-      countLayersInBottle < 10
-    ) {
-      dispatch(setCountLayersInBottle(countLayersInBottle + 1))
-      dispatch(setLastUpdateParam('countLayers'))
-    } else if (
-      (lastUpdateParam === '' || lastUpdateParam === 'countLayers') &&
-      countEmptyBottles >= 1
-    ) {
-      countEmptyBottles === 1
-        ? dispatch(setCountEmptyBottles(countEmptyBottles + 1))
-        : dispatch(setCountEmptyBottles(countEmptyBottles - 1))
-      dispatch(setLastUpdateParam('epmtyBottles'))
-    } else {
-      dispatch(setLastUpdateParam(''))
-      updateLevel()
+    switch (true) {
+      case countColors === 10 &&
+        countLayersInBottle === 10 &&
+        countEmptyBottles === 1:
+        dispatch(resetLevel())
+        break
+      case (!lastUpdateParam || lastUpdateParam === 'epmtyBottles') &&
+        countColors < 10:
+        dispatch(setCountColors(countColors + 1))
+        dispatch(setLastUpdateParam('countColors'))
+        break
+      case (!lastUpdateParam || lastUpdateParam === 'countColors') &&
+        countLayersInBottle < 10:
+        dispatch(setCountLayersInBottle(countLayersInBottle + 1))
+        dispatch(setLastUpdateParam('countLayers'))
+        break
+      case (!lastUpdateParam || lastUpdateParam === 'countLayers') &&
+        countEmptyBottles >= 1:
+        countEmptyBottles === 1
+          ? dispatch(setCountEmptyBottles(countEmptyBottles + 1))
+          : dispatch(setCountEmptyBottles(countEmptyBottles - 1))
+        dispatch(setLastUpdateParam('epmtyBottles'))
+        break
+      default:
+        dispatch(setLastUpdateParam(''))
+        break
     }
   }
 

--- a/packages/client/src/components/Game/FinishGame/index.tsx
+++ b/packages/client/src/components/Game/FinishGame/index.tsx
@@ -3,12 +3,12 @@ import thumbUp from '../../../assets/images/thumb-up.png'
 import Button from '../../Button'
 import { useStartLevel } from '../../../hooks/useStartLevel'
 import LoaderGame from '../LoaderGame'
+import { useAppSelector } from '../../../store/hooks'
 
 const FinishGame = () => {
-  // Переменные на этапе верстки
-  const finishedLevel = 1
-  const finisheTime = '04:17'
   const countAttempts = 10
+
+  const { currentTime, currentLevel } = useAppSelector(state => state.game)
 
   const { gameIsLoading, startGameHandler } = useStartLevel()
 
@@ -22,10 +22,10 @@ const FinishGame = () => {
         </div>
         <div className="finish-game__review finish-game-review">
           <div className="finish-game-review__level">
-            Уровень {finishedLevel} пройден
+            Уровень {currentLevel} пройден
           </div>
           <div className="finish-game-review__details">
-            <div className="finish-game-review__time">Время: {finisheTime}</div>
+            <div className="finish-game-review__time">Время: {currentTime}</div>
             <div className="finish-game-review__attempts">
               Переливаний: {countAttempts}
             </div>

--- a/packages/client/src/components/Game/FinishGame/index.tsx
+++ b/packages/client/src/components/Game/FinishGame/index.tsx
@@ -14,8 +14,10 @@ import {
   setCurrentAttempts,
   setCurrentTime,
   setLastUpdateParam,
+  setMode,
   setNextLevel,
 } from '../../../store/slices/gameSlice'
+import { useNavigate } from 'react-router-dom'
 
 const FinishGame = () => {
   const countAttempts = 10
@@ -23,13 +25,31 @@ const FinishGame = () => {
   const { currentTime, currentLevel, lastUpdateParam } = useAppSelector(
     state => state.game
   )
+
+  const navigate = useNavigate()
+
   const { countColors, countLayersInBottle, countEmptyBottles } =
     useAppSelector(state => state.level)
   const dispatch = useAppDispatch()
   const { gameIsLoading, startGameHandler } = useStartLevel()
 
+  function startNextLevel() {
+    updateLevel()
+    dispatch(setCurrentTime(''))
+    dispatch(setCurrentAttempts(0))
+    dispatch(setNextLevel())
+    startGameHandler()
+  }
+
+  function exitGameHandler() {
+    dispatch(setCurrentTime(''))
+    dispatch(setCurrentAttempts(0))
+    dispatch(setMode(null))
+    navigate('/start')
+  }
+
   /*
-  Алгоритм изменения уровня 
+  Алгоритм обновления уровня 
 Шаг N
     Увеличить Количество цветов на 1
 Шаг N+1
@@ -42,14 +62,6 @@ const FinishGame = () => {
 При достижении кейса Количество цветов = Количество ярусов = 10 и Количество пустых бутылок = 1 и если при этом игрок дошел до разрешения головоломки
  - игра не оканчивается и при нажатии на кнопку продолжить переходим на начальную конфигурацию уровня 3-4-2
   */
-
-  function startNextLevel() {
-    updateLevel()
-    dispatch(setCurrentTime(''))
-    dispatch(setCurrentAttempts(0))
-    dispatch(setNextLevel())
-    startGameHandler()
-  }
 
   function updateLevel() {
     if (
@@ -80,7 +92,7 @@ const FinishGame = () => {
       dispatch(setLastUpdateParam('epmtyBottles'))
     } else {
       dispatch(setLastUpdateParam(''))
-      setNextLevel()
+      updateLevel()
     }
   }
 
@@ -104,6 +116,9 @@ const FinishGame = () => {
           </div>
         </div>
         <div className="finish-game__btn">
+          <Button onClick={exitGameHandler} styleType="primary">
+            Главное меню
+          </Button>
           <Button onClick={startNextLevel} styleType="primary">
             Продолжить
           </Button>

--- a/packages/client/src/components/Game/SetupLevelGame/SetupLevelGame.pcss
+++ b/packages/client/src/components/Game/SetupLevelGame/SetupLevelGame.pcss
@@ -1,0 +1,40 @@
+.setup-level-header {
+  text-align: center;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+  &__title {
+    margin-bottom: 0.5rem;
+  }
+  &__subtitle {
+    font-size: 1.25rem;
+  }
+}
+
+.setup-level-body {
+  margin: 2rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  &__selector {
+    display: flex;
+    align-items: baseline;
+  }
+
+  select {
+    width: 100%;
+    background-color: transparent;
+    border: 3px solid var(--color-orange);
+    display: inline-flex;
+    padding: 0.5rem 1rem;
+    border-radius: var(--border-radius);
+  }
+
+  &__label {
+    min-width: 320px;
+    font-size: 1.125rem;
+  }
+}
+
+.setup-level-btn {
+  text-align: center;
+}

--- a/packages/client/src/components/Game/SetupLevelGame/index.tsx
+++ b/packages/client/src/components/Game/SetupLevelGame/index.tsx
@@ -71,7 +71,7 @@ const SetupLevelGame = ({ onCancelSettings, onStart }: Props) => {
           Количество ярусов в бутылке:
           <select
             onChange={e => dispatch(setCountLayersInBottle(+e.target.value))}
-            value={countEmptyBottles}>
+            value={countLayersInBottle}>
             {getLayersRange().map(num => (
               <option key={num} value={num}>
                 {num}
@@ -83,7 +83,7 @@ const SetupLevelGame = ({ onCancelSettings, onStart }: Props) => {
           Количество пустых бутылок:
           <select
             onChange={e => dispatch(setCountEmptyBottles(+e.target.value))}
-            value={countLayersInBottle}>
+            value={countEmptyBottles}>
             {getBottlesRange().map(num => (
               <option key={num} value={num}>
                 {num}

--- a/packages/client/src/components/Game/SetupLevelGame/index.tsx
+++ b/packages/client/src/components/Game/SetupLevelGame/index.tsx
@@ -1,0 +1,100 @@
+import createRange from '../../../helpers/createRange'
+import { useAppDispatch, useAppSelector } from '../../../store/hooks'
+import {
+  setCountColors,
+  setCountEmptyBottles,
+  setCountLayersInBottle,
+  updateLayersInBottle,
+} from '../../../store/slices/levelSlice'
+import Button from '../../Button'
+import { FaArrowLeft } from 'react-icons/fa'
+
+interface Props {
+  onCancelSettings: () => void
+  onStart: () => void
+}
+
+const SetupLevelGame = ({ onCancelSettings, onStart }: Props) => {
+  const iconBackStyle = { fill: 'var(--color-text-gray)', fontSize: '1.25rem' }
+
+  const {
+    countColors,
+    countLayersInBottle,
+    countEmptyBottles,
+    minCountColors,
+    maxCountColors,
+    minCountLayersInBottle,
+    maxCountLayersInBottle,
+    minCountEmptyBottles,
+    maxCountEmptyBottles,
+  } = useAppSelector(state => state.level)
+
+  const dispatch = useAppDispatch()
+
+  const getColorsRange = () => {
+    return createRange(minCountColors, maxCountColors)
+  }
+
+  const getLayersRange = () => {
+    return createRange(minCountLayersInBottle, maxCountLayersInBottle)
+  }
+
+  const getBottlesRange = () => {
+    return createRange(minCountEmptyBottles, maxCountEmptyBottles)
+  }
+
+  return (
+    <div className="card card_full">
+      <Button onClick={onCancelSettings} styleType="tertiary">
+        <FaArrowLeft style={iconBackStyle} />
+        Назад
+      </Button>
+      <h1>Головоломка</h1>
+      <p>Настройте начальный уровень сложности</p>
+      <div>
+        <div>
+          Количество цветов:
+          <select
+            onChange={e => {
+              dispatch(setCountColors(+e.target.value))
+              dispatch(updateLayersInBottle())
+            }}
+            value={countColors}>
+            {getColorsRange().map(num => (
+              <option key={num} value={num}>
+                {num}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          Количество ярусов в бутылке:
+          <select
+            onChange={e => dispatch(setCountLayersInBottle(+e.target.value))}
+            value={countEmptyBottles}>
+            {getLayersRange().map(num => (
+              <option key={num} value={num}>
+                {num}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          Количество пустых бутылок:
+          <select
+            onChange={e => dispatch(setCountEmptyBottles(+e.target.value))}
+            value={countLayersInBottle}>
+            {getBottlesRange().map(num => (
+              <option key={num} value={num}>
+                {num}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <Button onClick={onStart}>Start</Button>
+    </div>
+  )
+}
+
+export default SetupLevelGame

--- a/packages/client/src/components/Game/SetupLevelGame/index.tsx
+++ b/packages/client/src/components/Game/SetupLevelGame/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../store/slices/levelSlice'
 import Button from '../../Button'
 import { FaArrowLeft } from 'react-icons/fa'
+import './SetupLevelGame.pcss'
 
 interface Props {
   onCancelSettings: () => void
@@ -49,11 +50,15 @@ const SetupLevelGame = ({ onCancelSettings, onStart }: Props) => {
         <FaArrowLeft style={iconBackStyle} />
         Назад
       </Button>
-      <h1>Головоломка</h1>
-      <p>Настройте начальный уровень сложности</p>
-      <div>
-        <div>
-          Количество цветов:
+      <div className="setup-level-header">
+        <h1 className="setup-level-header__title">Головоломка</h1>
+        <div className="setup-level-header__subtitle">
+          Настройте начальный уровень сложности
+        </div>
+      </div>
+      <div className="setup-level-body">
+        <div className="setup-level-body__selector">
+          <label className="setup-level-body__label">Количество цветов:</label>
           <select
             onChange={e => {
               dispatch(setCountColors(+e.target.value))
@@ -67,8 +72,10 @@ const SetupLevelGame = ({ onCancelSettings, onStart }: Props) => {
             ))}
           </select>
         </div>
-        <div>
-          Количество ярусов в бутылке:
+        <div className="setup-level-body__selector">
+          <label className="setup-level-body__label">
+            Количество ярусов в бутылке:
+          </label>
           <select
             onChange={e => dispatch(setCountLayersInBottle(+e.target.value))}
             value={countLayersInBottle}>
@@ -79,8 +86,10 @@ const SetupLevelGame = ({ onCancelSettings, onStart }: Props) => {
             ))}
           </select>
         </div>
-        <div>
-          Количество пустых бутылок:
+        <div className="setup-level-body__selector">
+          <label className="setup-level-body__label">
+            Количество пустых бутылок:
+          </label>
           <select
             onChange={e => dispatch(setCountEmptyBottles(+e.target.value))}
             value={countEmptyBottles}>
@@ -92,7 +101,9 @@ const SetupLevelGame = ({ onCancelSettings, onStart }: Props) => {
           </select>
         </div>
       </div>
-      <Button onClick={onStart}>Start</Button>
+      <div className="setup-level-btn">
+        <Button onClick={onStart}>Начать</Button>
+      </div>
     </div>
   )
 }

--- a/packages/client/src/components/Game/StartGame/StartGameNav/index.tsx
+++ b/packages/client/src/components/Game/StartGame/StartGameNav/index.tsx
@@ -5,14 +5,16 @@ import iconModeBattle from '../../../../assets/icons/icon-mode-1.svg'
 import iconModePuzzle from '../../../../assets/icons/icon-mode-2.svg'
 import { useAppDispatch } from '../../../../store/hooks'
 import { logoutUser } from '../../../../store/slices/userSlice/userAsyncThunks'
+import { GameMode } from '../../../../store/slices/gameSlice/types'
 
 interface Props {
-  onStart: () => void
+  onSetupSettings: (mode: GameMode) => void
 }
 
-const StartGameNav = ({ onStart }: Props) => {
+const StartGameNav = ({ onSetupSettings }: Props) => {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
+
   const handleQuit = async () => {
     const res = await dispatch(logoutUser())
     if (logoutUser.fulfilled.match(res)) {
@@ -23,18 +25,14 @@ const StartGameNav = ({ onStart }: Props) => {
   return (
     <div className="game-start-nav">
       <div className="game-start-nav__switch-mode">
-        <Button
-          width="100%"
-          height="80px"
-          onClick={onStart}
-          styleType="primary">
+        <Button width="100%" height="80px" disabled={true} styleType="primary">
           <img src={iconModeBattle} />
           Сражения
         </Button>
         <Button
           width="100%"
           height="80px"
-          onClick={onStart}
+          onClick={() => onSetupSettings('puzzle')}
           styleType="primary">
           <img src={iconModePuzzle} />
           Головоломка

--- a/packages/client/src/components/Game/StartGame/index.tsx
+++ b/packages/client/src/components/Game/StartGame/index.tsx
@@ -4,19 +4,49 @@ import StartGameNav from './StartGameNav'
 import './StartGame.pcss'
 import LoaderGame from '../LoaderGame'
 import { useStartLevel } from '../../../hooks/useStartLevel'
+import { useAppDispatch, useAppSelector } from '../../../store/hooks'
+import SetupLevelGame from '../SetupLevelGame'
+import { GameMode } from '../../../store/slices/gameSlice/types'
+import {
+  setIsSetupLevelSettings,
+  setNextLevel,
+  setMode,
+} from '../../../store/slices/gameSlice'
 
 const StartGame = () => {
   const { gameIsLoading, startGameHandler } = useStartLevel()
+  const { mode, isSetupLevelSettings } = useAppSelector(state => state.game)
+
+  const dispatch = useAppDispatch()
+
+  function setupSettingsHandler(mode: GameMode) {
+    dispatch(setMode(mode))
+    dispatch(setIsSetupLevelSettings(true))
+  }
+
+  function cancelSettingsHandler() {
+    dispatch(setMode(null))
+    dispatch(setIsSetupLevelSettings(false))
+  }
 
   return (
     <div className="start-game">
       {gameIsLoading ? (
         <LoaderGame />
+      ) : mode && isSetupLevelSettings ? (
+        <SetupLevelGame
+          onCancelSettings={cancelSettingsHandler}
+          onStart={() => {
+            dispatch(setIsSetupLevelSettings(false))
+            dispatch(setNextLevel())
+            startGameHandler()
+          }}
+        />
       ) : (
         <>
           <StartGameHeader />
           <StartGameImage />
-          <StartGameNav onStart={startGameHandler} />
+          <StartGameNav onSetupSettings={setupSettingsHandler} />
         </>
       )}
     </div>

--- a/packages/client/src/components/Game/StartGame/index.tsx
+++ b/packages/client/src/components/Game/StartGame/index.tsx
@@ -9,7 +9,6 @@ import SetupLevelGame from '../SetupLevelGame'
 import { GameMode } from '../../../store/slices/gameSlice/types'
 import {
   setIsSetupLevelSettings,
-  setNextLevel,
   setMode,
 } from '../../../store/slices/gameSlice'
 
@@ -38,7 +37,6 @@ const StartGame = () => {
           onCancelSettings={cancelSettingsHandler}
           onStart={() => {
             dispatch(setIsSetupLevelSettings(false))
-            dispatch(setNextLevel())
             startGameHandler()
           }}
         />

--- a/packages/client/src/components/Profile/index.tsx
+++ b/packages/client/src/components/Profile/index.tsx
@@ -8,7 +8,6 @@ import { useAppSelector } from '../../store/hooks'
 const Profile = () => {
   const { user } = useAppSelector(state => state.user)
   const navigate = useNavigate()
-
   return (
     <>
       {user ? (

--- a/packages/client/src/helpers/createRange.ts
+++ b/packages/client/src/helpers/createRange.ts
@@ -1,0 +1,9 @@
+const createRange = (start: number, end: number): number[] => {
+  const step = 1
+  return Array.from(
+    { length: (end - start) / step + 1 },
+    (value, index) => start + index * step
+  )
+}
+
+export default createRange

--- a/packages/client/src/hooks/useTimer.ts
+++ b/packages/client/src/hooks/useTimer.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+
+export const useTimer = () => {
+  const [time, setTime] = useState(0)
+
+  let timer: ReturnType<typeof setInterval>
+  const minutes = Math.floor((time % 360000) / 6000)
+  const seconds = Math.floor((time % 6000) / 100)
+
+  function timerStart() {
+    timer = setInterval(() => {
+      setTime(prev => prev + 1)
+    }, 10)
+  }
+  function timerStop() {
+    clearInterval(timer)
+  }
+  function timerReset() {
+    clearInterval(timer)
+    setTime(0)
+  }
+
+  function getTime() {
+    return `${minutes.toString().padStart(2, '0')}:${seconds
+      .toString()
+      .padStart(2, '0')}`
+  }
+
+  return { timerStart, timerStop, timerReset, getTime, time }
+}

--- a/packages/client/src/layouts/Layout.tsx
+++ b/packages/client/src/layouts/Layout.tsx
@@ -4,7 +4,7 @@ import Navigation from '../components/Navigation/Navigation'
 const Layout = () => {
   return (
     <>
-      <Navigation />
+      {/* <Navigation /> */}
       <Outlet />
     </>
   )

--- a/packages/client/src/pages/ErrorPage/ErrorPage.tsx
+++ b/packages/client/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import Button from '../../components/Button'
 import ErrorInformer, {
   ErrorInformerProps,
@@ -9,6 +10,8 @@ const ErrorPage: React.FC<ErrorInformerProps> = ({
   errorText,
   errorStatus,
 }) => {
+  const navigate = useNavigate()
+
   return (
     <div className="error-page">
       <ErrorInformer
@@ -17,7 +20,11 @@ const ErrorPage: React.FC<ErrorInformerProps> = ({
         errorText={errorText}
         errorStatus={errorStatus}
       />
-      <Button type="submit" width="150px" height="48px">
+      <Button
+        onClick={() => navigate('/')}
+        type="submit"
+        width="150px"
+        height="48px">
         На главную
       </Button>
       <img className="error-page-wave" src="wave.png" alt="wave" />

--- a/packages/client/src/pages/FinishPage.tsx
+++ b/packages/client/src/pages/FinishPage.tsx
@@ -1,21 +1,9 @@
-import { useNavigate } from 'react-router-dom'
-import Button from '../components/Button'
 import FinishGame from '../components/Game/FinishGame'
-import { FaArrowLeft } from 'react-icons/fa'
 
 const FinishPage = () => {
-  const navigate = useNavigate()
-  const iconBackStyle = { fill: 'var(--color-white)', fontSize: '1.25rem' }
-
   return (
     <div className="page-wrap page-wrap_lightblue">
       <main className="container">
-        <div className="page-finish-nav">
-          <Button styleType="primary" onClick={() => navigate('/start')}>
-            <FaArrowLeft style={iconBackStyle} />
-            Главное меню
-          </Button>
-        </div>
         <FinishGame />
       </main>
       <img className="page-wrap__wave" src="wave.png" alt="wave" />

--- a/packages/client/src/pages/LeaderbordPage.tsx
+++ b/packages/client/src/pages/LeaderbordPage.tsx
@@ -16,7 +16,7 @@ const LeaderbordPage = () => {
 
   return (
     <div className="page-wrap page-wrap_lightblue">
-      <main className="container card card_height-full">
+      <main className="container card card_full">
         <Button onClick={() => navigate(-1)} styleType="tertiary">
           <FaArrowLeft style={iconBackStyle} />
           Назад

--- a/packages/client/src/pages/LeaderbordPage.tsx
+++ b/packages/client/src/pages/LeaderbordPage.tsx
@@ -16,7 +16,7 @@ const LeaderbordPage = () => {
 
   return (
     <div className="page-wrap page-wrap_lightblue">
-      <main className="container card card_full">
+      <main className="container card card_height-full">
         <Button onClick={() => navigate(-1)} styleType="tertiary">
           <FaArrowLeft style={iconBackStyle} />
           Назад

--- a/packages/client/src/pages/LevelPage.tsx
+++ b/packages/client/src/pages/LevelPage.tsx
@@ -1,7 +1,11 @@
 import Bottle from '../components/Bottle/index'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import FillTypeColor from '../components/Bottle/FillTypeColor'
 import { FunctionArray } from '../utils/FunctionArray'
+import { useAppDispatch, useAppSelector } from '../store/hooks'
+import { useNavigate } from 'react-router-dom'
+import { useTimer } from '../hooks/useTimer'
+import { setCurrentTime } from '../store/slices/gameSlice'
 
 interface Props {
   initCountColor?: number
@@ -46,7 +50,17 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
 
   const [selectKeyForBottle, setSelectKeyForBottle] = useState('-1')
 
-  const [countColor, setCountColor] = useState(initCountColor)
+  // const [countColor, setCountColor] = useState(initCountColor)
+  
+  // Три переменные из стора для инициализации уровя
+  const { countColors, countEmptyBottles, countLayersInBottle } =
+    useAppSelector(state => state.level)
+  const { currentLevel } = useAppSelector(state => state.game)
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
+  const { timerStart, timerStop, getTime } = useTimer()
+
+  const [countColor, setCountColor] = useState(countColors)
 
   const saveCallbackFinishBottle = (callbackFinishBottle: () => boolean) => {
     arrayCallbackBottleIsComplete.push(callbackFinishBottle)
@@ -57,7 +71,9 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
       bottleIsComplete => bottleIsComplete()
     )
     if (allBottleIsComplete) {
-      setDisplay('block')
+      // setDisplay('block')
+      dispatch(setCurrentTime(getTime()))
+      navigate('/finish')
     }
   }
 
@@ -135,6 +151,14 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
     return infoForRenderBottle
   }
 
+  useEffect(() => {
+    reCreateAllBottles()
+    timerStart()
+    return () => {
+      timerStop()
+    }
+  }, [])
+
   function reCreateAllBottles() {
     setArraySettingsBottle(createArrayBottle())
   }
@@ -145,29 +169,28 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
     setCountColor(Number(event.target.value))
   }
 
-  function activateFullscreen(element : Element) {
-    if(element.requestFullscreen) {
-      element.requestFullscreen();        // W3C spec
+  function activateFullscreen(element: Element) {
+    if (element.requestFullscreen) {
+      element.requestFullscreen() // W3C spec
     }
-  };
-  
+  }
+
   function deactivateFullscreen() {
-    if(document.exitFullscreen) {
-      document.exitFullscreen();
+    if (document.exitFullscreen) {
+      document.exitFullscreen()
     }
-  };
+  }
 
   function fullScreenToggle() {
-    let caption = document!.getElementById("toggler")!.innerHTML; 
-    if (caption == "Полный экран") {
-      activateFullscreen(document.documentElement);
-      caption = "В окне"
+    let caption = document!.getElementById('toggler')!.innerHTML
+    if (caption == 'Полный экран') {
+      activateFullscreen(document.documentElement)
+      caption = 'В окне'
+    } else {
+      deactivateFullscreen()
+      caption = 'Полный экран'
     }
-    else {
-      deactivateFullscreen();
-      caption = "Полный экран"
-    }
-    document!.getElementById("toggler")!.innerHTML = caption;
+    document!.getElementById('toggler')!.innerHTML = caption
   }
 
   return (
@@ -184,9 +207,14 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
         <button onClick={reCreateAllBottles} style={{ marginLeft: '20px' }}>
           Применить
         </button>
-        <button id="toggler" onClick={fullScreenToggle} style={{ marginLeft: '20px' }}>
+        <button
+          id="toggler"
+          onClick={fullScreenToggle}
+          style={{ marginLeft: '20px' }}>
           Полный экран
         </button>
+        <div>Время: {getTime()}</div>
+        <div>Уровень: {currentLevel}</div>
       </div>
       {arraySettingsBottle.map((bottle, idx) => (
         <Bottle

--- a/packages/client/src/pages/LevelPage.tsx
+++ b/packages/client/src/pages/LevelPage.tsx
@@ -5,7 +5,11 @@ import { FunctionArray } from '../utils/FunctionArray'
 import { useAppDispatch, useAppSelector } from '../store/hooks'
 import { useNavigate } from 'react-router-dom'
 import { useTimer } from '../hooks/useTimer'
-import { setCurrentTime } from '../store/slices/gameSlice'
+import {
+  setCurrentAttempts,
+  setCurrentTime,
+  setMode,
+} from '../store/slices/gameSlice'
 
 interface Props {
   initCountColor?: number
@@ -193,6 +197,13 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
     document!.getElementById('toggler')!.innerHTML = caption
   }
 
+  function exitGameHandler() {
+    dispatch(setCurrentTime(''))
+    dispatch(setCurrentAttempts(0))
+    dispatch(setMode(null))
+    navigate('/start')
+  }
+
   return (
     <div>
       <div style={{ margin: '20px' }}>
@@ -212,6 +223,9 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
           onClick={fullScreenToggle}
           style={{ marginLeft: '20px' }}>
           Полный экран
+        </button>
+        <button onClick={exitGameHandler} style={{ marginLeft: '20px' }}>
+          Выйти
         </button>
         <div>Время: {getTime()}</div>
         <div>Уровень: {currentLevel}</div>

--- a/packages/client/src/pages/LevelPage.tsx
+++ b/packages/client/src/pages/LevelPage.tsx
@@ -51,7 +51,7 @@ const LevelPage = ({ initCountColor = 2 }: Props) => {
   const [selectKeyForBottle, setSelectKeyForBottle] = useState('-1')
 
   // const [countColor, setCountColor] = useState(initCountColor)
-  
+
   // Три переменные из стора для инициализации уровя
   const { countColors, countEmptyBottles, countLayersInBottle } =
     useAppSelector(state => state.level)

--- a/packages/client/src/pages/MiniLendingPage/MiniLendingPage.tsx
+++ b/packages/client/src/pages/MiniLendingPage/MiniLendingPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import Button from '../../components/Button'
 import DevFooter, { DevFooterElement } from '../../components/DevFooter'
 import Memo from '../../components/Memo'
@@ -26,6 +27,9 @@ const MiniLendingPage = () => {
       devAvatar: 'kseniya.png',
     },
   ]
+
+  const navigate = useNavigate()
+
   return (
     <div className="mini-lending-page">
       <div className="first-screen">
@@ -37,7 +41,7 @@ const MiniLendingPage = () => {
           rws={4}
           cls={80}
         />
-        <Button type="submit" width="150px" height="48px">
+        <Button onClick={() => navigate('/start')} type="submit" width="150px" height="48px">
           Начать игру
         </Button>
         <img

--- a/packages/client/src/pages/MiniLendingPage/MiniLendingPage.tsx
+++ b/packages/client/src/pages/MiniLendingPage/MiniLendingPage.tsx
@@ -41,7 +41,11 @@ const MiniLendingPage = () => {
           rws={4}
           cls={80}
         />
-        <Button onClick={() => navigate('/start')} type="submit" width="150px" height="48px">
+        <Button
+          onClick={() => navigate('/start')}
+          type="submit"
+          width="150px"
+          height="48px">
           Начать игру
         </Button>
         <img

--- a/packages/client/src/pages/ProfilePage.tsx
+++ b/packages/client/src/pages/ProfilePage.tsx
@@ -16,7 +16,7 @@ const ProfilePage = () => {
 
   return (
     <div className="page-wrap page-wrap_lightblue">
-      <main className="container card card_full">
+      <main className="container card card_height-full">
         <Button onClick={() => navigate(-1)} styleType="tertiary">
           <FaArrowLeft style={iconBackStyle} />
           Назад

--- a/packages/client/src/pages/ProfilePage.tsx
+++ b/packages/client/src/pages/ProfilePage.tsx
@@ -1,8 +1,8 @@
-import Button from '../components/Button'
-import { FaArrowLeft } from 'react-icons/fa'
 import { useNavigate } from 'react-router-dom'
 import Profile from '../components/Profile'
 import { useEffect } from 'react'
+import { FaArrowLeft } from 'react-icons/fa'
+import Button from '../components/Button'
 
 const ProfilePage = () => {
   const navigate = useNavigate()
@@ -16,11 +16,12 @@ const ProfilePage = () => {
 
   return (
     <div className="page-wrap page-wrap_lightblue">
-      <main className="container card card_height-full">
+      <main className="container card card_full">
         <Button onClick={() => navigate(-1)} styleType="tertiary">
           <FaArrowLeft style={iconBackStyle} />
           Назад
         </Button>
+
         <Profile />
       </main>
       <img className="page-wrap__wave" src="wave.png" alt="wave" />

--- a/packages/client/src/routes/routes.tsx
+++ b/packages/client/src/routes/routes.tsx
@@ -1,8 +1,6 @@
 import { Route, Routes } from 'react-router-dom'
 import Layout from '../layouts/Layout'
 import ProfilePage from '../pages/ProfilePage'
-import HomePage from '../pages/HomePage'
-import NotFoundPage from '../pages/NotFoundPage'
 import ForumPage from '../pages/Forum/ForumPage'
 import SignInPage from '../pages/SignInPage'
 import SignUpPage from '../pages/SignUpPage'
@@ -19,7 +17,6 @@ const RoutesBase = () => {
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
-        {/* <Route index element={<HomePage />} /> */}
         <Route index element={<MiniLendingPage />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route
@@ -76,7 +73,6 @@ const RoutesBase = () => {
             />
           }
         />
-        {/* <Route path="/minilending" element={<MiniLendingPage />} /> */}
       </Route>
       <Route
         path="*"

--- a/packages/client/src/routes/routes.tsx
+++ b/packages/client/src/routes/routes.tsx
@@ -78,7 +78,16 @@ const RoutesBase = () => {
         />
         {/* <Route path="/minilending" element={<MiniLendingPage />} /> */}
       </Route>
-      <Route path="*" element={<NotFoundPage />} />
+      <Route
+        path="*"
+        element={
+          <ErrorPage
+            errorCode="404"
+            errorText="К сожалению, запрашиваемая страница не найдена"
+            errorStatus="Some status"
+          />
+        }
+      />
     </Routes>
   )
 }

--- a/packages/client/src/routes/routes.tsx
+++ b/packages/client/src/routes/routes.tsx
@@ -19,7 +19,8 @@ const RoutesBase = () => {
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
-        <Route index element={<HomePage />} />
+        {/* <Route index element={<HomePage />} /> */}
+        <Route index element={<MiniLendingPage />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route
           path="/forum"
@@ -75,7 +76,7 @@ const RoutesBase = () => {
             />
           }
         />
-        <Route path="/minilending" element={<MiniLendingPage />} />
+        {/* <Route path="/minilending" element={<MiniLendingPage />} /> */}
       </Route>
       <Route path="*" element={<NotFoundPage />} />
     </Routes>

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit'
 import userReducer from './slices/userSlice'
 import gameReducer from './slices/gameSlice'
+import levelReducer from './slices/levelSlice'
 
 const store = configureStore({
   reducer: {
     user: userReducer,
     game: gameReducer,
+    level: levelReducer
   },
 })
 

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -7,7 +7,7 @@ const store = configureStore({
   reducer: {
     user: userReducer,
     game: gameReducer,
-    level: levelReducer
+    level: levelReducer,
   },
 })
 

--- a/packages/client/src/store/slices/gameSlice/index.ts
+++ b/packages/client/src/store/slices/gameSlice/index.ts
@@ -1,4 +1,4 @@
-import { GameDifficulty, GameMode } from './types'
+import { GameMode } from './types'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 interface GameState {
@@ -8,17 +8,15 @@ interface GameState {
   currentAttempts: number
   currentTime: string
   lastUpdateParam: string
-  // selectedDifficulty: GameDifficulty | null
 }
 
 const initialState: GameState = {
   mode: null,
-  currentLevel: 0,
+  currentLevel: 1,
   currentAttempts: 0,
   currentTime: '',
   isSetupLevelSettings: false,
   lastUpdateParam: '',
-  // selectedDifficulty: null,
 }
 
 const gameSlice = createSlice({

--- a/packages/client/src/store/slices/gameSlice/index.ts
+++ b/packages/client/src/store/slices/gameSlice/index.ts
@@ -17,7 +17,7 @@ const initialState: GameState = {
   currentAttempts: 0,
   currentTime: '',
   isSetupLevelSettings: false,
-  lastUpdateParam: ''
+  lastUpdateParam: '',
   // selectedDifficulty: null,
 }
 
@@ -40,9 +40,9 @@ const gameSlice = createSlice({
     setLastUpdateParam(state, action: PayloadAction<string>) {
       state.lastUpdateParam = action.payload
     },
-    setCurrentAttempts(state, action:PayloadAction<number>) {
+    setCurrentAttempts(state, action: PayloadAction<number>) {
       state.currentAttempts = action.payload
-    }
+    },
   },
 })
 
@@ -52,6 +52,6 @@ export const {
   setCurrentTime,
   setNextLevel,
   setLastUpdateParam,
-  setCurrentAttempts
+  setCurrentAttempts,
 } = gameSlice.actions
 export default gameSlice.reducer

--- a/packages/client/src/store/slices/gameSlice/index.ts
+++ b/packages/client/src/store/slices/gameSlice/index.ts
@@ -1,12 +1,13 @@
 import { GameDifficulty, GameMode } from './types'
-import { createSlice } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 interface GameState {
   mode: GameMode | null
+  isSetupLevelSettings: boolean
   currentLevel: number
   currentAttempts: number
   currentTime: string
-  selectedDifficulty: GameDifficulty | null
+  // selectedDifficulty: GameDifficulty | null
 }
 
 const initialState: GameState = {
@@ -14,13 +15,33 @@ const initialState: GameState = {
   currentLevel: 0,
   currentAttempts: 0,
   currentTime: '',
-  selectedDifficulty: null,
+  isSetupLevelSettings: false,
+  // selectedDifficulty: null,
 }
 
 const gameSlice = createSlice({
   name: 'game',
   initialState,
-  reducers: {},
+  reducers: {
+    setMode: (state, action: PayloadAction<GameMode | null>) => {
+      state.mode = action.payload
+    },
+    setIsSetupLevelSettings: (state, action: PayloadAction<boolean>) => {
+      state.isSetupLevelSettings = action.payload
+    },
+    setCurrentTime: (state, action: PayloadAction<string>) => {
+      state.currentTime = action.payload
+    },
+    setNextLevel: state => {
+      state.currentLevel += 1
+    },
+  },
 })
 
+export const {
+  setMode,
+  setIsSetupLevelSettings,
+  setCurrentTime,
+  setNextLevel,
+} = gameSlice.actions
 export default gameSlice.reducer

--- a/packages/client/src/store/slices/gameSlice/index.ts
+++ b/packages/client/src/store/slices/gameSlice/index.ts
@@ -7,6 +7,7 @@ interface GameState {
   currentLevel: number
   currentAttempts: number
   currentTime: string
+  lastUpdateParam: string
   // selectedDifficulty: GameDifficulty | null
 }
 
@@ -16,6 +17,7 @@ const initialState: GameState = {
   currentAttempts: 0,
   currentTime: '',
   isSetupLevelSettings: false,
+  lastUpdateParam: ''
   // selectedDifficulty: null,
 }
 
@@ -35,6 +37,12 @@ const gameSlice = createSlice({
     setNextLevel: state => {
       state.currentLevel += 1
     },
+    setLastUpdateParam(state, action: PayloadAction<string>) {
+      state.lastUpdateParam = action.payload
+    },
+    setCurrentAttempts(state, action:PayloadAction<number>) {
+      state.currentAttempts = action.payload
+    }
   },
 })
 
@@ -43,5 +51,7 @@ export const {
   setIsSetupLevelSettings,
   setCurrentTime,
   setNextLevel,
+  setLastUpdateParam,
+  setCurrentAttempts
 } = gameSlice.actions
 export default gameSlice.reducer

--- a/packages/client/src/store/slices/levelSlice/index.ts
+++ b/packages/client/src/store/slices/levelSlice/index.ts
@@ -54,9 +54,11 @@ const levelSlice = createSlice({
       state.minCountLayersInBottle =
         state.countColors === LIMIT ? state.countColors : state.countColors + 1
     },
-    setNextLevel: () => {
-      console.log('next level')
-    },
+    resetLevel: (state) => {
+      state.countColors = INIT_COUNT_COLORS
+      state.countEmptyBottles = INIT_EMPTY_BOTTLES
+      state.countLayersInBottle = INIT_COUNT_LAYERS
+    }
   },
 })
 
@@ -65,5 +67,6 @@ export const {
   setCountLayersInBottle,
   setCountEmptyBottles,
   updateLayersInBottle,
+  resetLevel
 } = levelSlice.actions
 export default levelSlice.reducer

--- a/packages/client/src/store/slices/levelSlice/index.ts
+++ b/packages/client/src/store/slices/levelSlice/index.ts
@@ -54,11 +54,11 @@ const levelSlice = createSlice({
       state.minCountLayersInBottle =
         state.countColors === LIMIT ? state.countColors : state.countColors + 1
     },
-    resetLevel: (state) => {
+    resetLevel: state => {
       state.countColors = INIT_COUNT_COLORS
       state.countEmptyBottles = INIT_EMPTY_BOTTLES
       state.countLayersInBottle = INIT_COUNT_LAYERS
-    }
+    },
   },
 })
 
@@ -67,6 +67,6 @@ export const {
   setCountLayersInBottle,
   setCountEmptyBottles,
   updateLayersInBottle,
-  resetLevel
+  resetLevel,
 } = levelSlice.actions
 export default levelSlice.reducer

--- a/packages/client/src/store/slices/levelSlice/index.ts
+++ b/packages/client/src/store/slices/levelSlice/index.ts
@@ -1,0 +1,69 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+interface LevelState {
+  countColors: number
+  countLayersInBottle: number
+  countEmptyBottles: number
+  minCountColors: number
+  maxCountColors: number
+  minCountLayersInBottle: number
+  maxCountLayersInBottle: number
+  minCountEmptyBottles: number
+  maxCountEmptyBottles: number
+}
+
+const LIMIT = 10
+const INIT_COUNT_COLORS = 3
+const INIT_COUNT_LAYERS = 4
+const INIT_EMPTY_BOTTLES = 2
+const MIN_EMPTY_BOTTLES = 1
+const LIMIT_EMPTY_BOTTLES = 3
+
+const initialState: LevelState = {
+  countColors: INIT_COUNT_COLORS,
+  countLayersInBottle: INIT_COUNT_LAYERS,
+  countEmptyBottles: INIT_EMPTY_BOTTLES,
+  minCountColors: INIT_COUNT_COLORS,
+  minCountLayersInBottle: INIT_COUNT_LAYERS,
+  minCountEmptyBottles: MIN_EMPTY_BOTTLES,
+  maxCountColors: LIMIT,
+  maxCountLayersInBottle: LIMIT,
+  maxCountEmptyBottles: LIMIT_EMPTY_BOTTLES,
+}
+
+const levelSlice = createSlice({
+  name: 'level',
+  initialState,
+  reducers: {
+    setCountColors: (state, action: PayloadAction<number>) => {
+      state.countColors = action.payload
+    },
+    setCountLayersInBottle: (state, action: PayloadAction<number>) => {
+      state.countLayersInBottle = action.payload
+    },
+    setCountEmptyBottles: (state, action: PayloadAction<number>) => {
+      state.countEmptyBottles = action.payload
+    },
+    updateLayersInBottle: state => {
+      if (state.countColors !== state.countLayersInBottle) {
+        state.countLayersInBottle =
+          state.countColors === LIMIT
+            ? state.countColors
+            : state.countColors + 1
+      }
+      state.minCountLayersInBottle =
+        state.countColors === LIMIT ? state.countColors : state.countColors + 1
+    },
+    setNextLevel: () => {
+      console.log('next level')
+    },
+  },
+})
+
+export const {
+  setCountColors,
+  setCountLayersInBottle,
+  setCountEmptyBottles,
+  updateLayersInBottle,
+} = levelSlice.actions
+export default levelSlice.reducer

--- a/packages/client/src/styles/App.pcss
+++ b/packages/client/src/styles/App.pcss
@@ -65,6 +65,12 @@
       max-height: calc(100vh - 6rem);
       overflow-y: auto;
     }
+    &_height-full {
+      width: 100%;
+      max-width: 800px;
+      padding: 3rem;
+      height: 100%;
+    }
   }
 
   &__wave {

--- a/packages/client/src/styles/App.pcss
+++ b/packages/client/src/styles/App.pcss
@@ -58,6 +58,8 @@
     background-color: var(--color-white);
     border-radius: var(--border-radius-card);
     &_full {
+      width: 100%;
+      max-width: 800px;
       padding: 3rem;
       height: auto;
       max-height: calc(100vh - 6rem);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,7 +1980,7 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
-"@reduxjs/toolkit@^1.9.5":
+"@reduxjs/toolkit@1.9.5":
   version "1.9.5"
   resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.9.5.tgz#d3987849c24189ca483baa7aa59386c8e52077c4"
   integrity sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==
@@ -7712,7 +7712,7 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-redux@^8.0.5:
+react-redux@8.0.5:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.5.tgz#e5fb8331993a019b8aaf2e167a93d10af469c7bd"
   integrity sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==


### PR DESCRIPTION
### Что было сделано:
1. Добавил новый стор levelSlice в redux, для хранения текущего состояния уровня, переменные проинициализировал базовым состоянием + добавил минимум и максимум кастомизации.
2. Добавил компонент SetupLevelGame с настройками уровня на странице /start
3. На странице завершения уровня /finish добавил алгоритм, который повышает уровень, если пользователя решает продолжить игру. Также на этой странице добавил кнопку выхода в главное меню
4. Добавил кастомный хук useTimer, который считает продолжительность прохождения уровня.

### Дополнительно в задаче сделал:
1. Убрал временную навигацию по приложению
2. Изменил главную страницу на роут с лэндингом

Экран с настройкой уровня:
<img width="1069" alt="Снимок экрана 2023-05-15 в 15 06 18" src="https://github.com/theotheo46/react/assets/18618740/0fae5327-21f7-4982-999a-00cef5ea2e1f">

Экран завершения уровня:
<img width="994" alt="Снимок экрана 2023-05-15 в 15 08 25" src="https://github.com/theotheo46/react/assets/18618740/d825baee-0198-4bcf-9f9a-6190e04e17b8">
